### PR TITLE
Update for unRaid 6.4

### DIFF
--- a/Resources/usr/local/emhttp/plugins/serverlayout/php/serverlayout_constants.php
+++ b/Resources/usr/local/emhttp/plugins/serverlayout/php/serverlayout_constants.php
@@ -80,7 +80,7 @@ $default_disk = array("TRAY_NUM"            => "",
                       "COLOR"               => "",
                       );
 
-$default_disk_data = array("DISK_DATA" => "");
+$default_disk_data = array("DISK_DATA" => array());
 
 $profiler .= microtime(true) . ",Get_JSON_Config_File()" . "\n";
 $myJSONconfig = Get_JSON_Config_File();  // Get or create JSON configuration file


### PR DESCRIPTION
PHP7 has stricter typing than PHP5 causing the crash