### PR TITLE
Fix non-quoted constant

### DIFF
--- a/Resources/usr/local/emhttp/plugins/serverlayout/php/serverlayout_data.php
+++ b/Resources/usr/local/emhttp/plugins/serverlayout/php/serverlayout_data.php
@@ -130,7 +130,7 @@ function TrayOptionsStartup() {
   // Create initial_trays array for all disks found
   var initial_trays = [<?php $first = true;
                              foreach ($myJSONconfig["DISK_DATA"] as $disk) {
-                               if (($disk["STATUS"] == "INSTALLED") and ($disk["TYPE"] != USB)) {
+                               if (($disk["STATUS"] == "INSTALLED") and ($disk["TYPE"] != "USB")) {
                                  if ($first) {
                                    $first = false;
                                    echo "\"".$disk["TRAY_NUM"]."\"";


### PR DESCRIPTION
Starting with PHP 7.2, a non quoted constant will throw a warning.  A later version of PHP will throw an error.  Even though unRaid 6.5, PHP warnings are disabled by default (unless turned on via Tips & Tweaks), this will eventually cause an issue.